### PR TITLE
Fixes using currentDownloadRequest variable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ var MIN_MULTIPART_SIZE = 5 * 1024 * 1024;
 
 var TO_UNIX_RE = new RegExp(quotemeta(path.sep), 'g');
 
-var currentDownloadRequest;
+var currentDownloadRequest = null;
 
 exports.createClient = function(options) {
   return new Client(options);
@@ -524,6 +524,7 @@ Client.prototype.downloadFile = function(params) {
         outStream.on('close', function() {
           if (errorOccurred) return;
           hashCheckPend.wait(cb);
+          currentDownloadRequest = null;
         });
 
         httpStream.pipe(multipartETag);
@@ -546,6 +547,7 @@ Client.prototype.downloadFile = function(params) {
 Client.prototype.abortCurrentDownload = function() {
   if (currentDownloadRequest) {
     setTimeout(currentDownloadRequest.abort.bind(currentDownloadRequest), 0)
+    currentDownloadRequest = null
   }
 }
 
@@ -807,6 +809,7 @@ Client.prototype.downloadBuffer = function(s3Params) {
   function doTheDownload(cb) {
     var errorOccurred = false;
     var request = self.s3.getObject(s3Params);
+    currentDownloadRequest = request;
     var hashCheckPend = new Pend();
     request.on('httpHeaders', function(statusCode, headers, resp) {
       if (statusCode >= 300) {
@@ -850,6 +853,7 @@ Client.prototype.downloadBuffer = function(s3Params) {
         hashCheckPend.wait(function() {
           cb(null, outStream.toBuffer());
         });
+        currentDownloadRequest = null;
       });
 
       httpStream.pipe(multipartETag);
@@ -890,6 +894,7 @@ Client.prototype.downloadStream = function(s3Params) {
   function doTheDownload(cb) {
     var errorOccurred = false;
     var request = self.s3.getObject(s3Params);
+    currentDownloadRequest = request;
     var hashCheckPend = new Pend();
     request.on('httpHeaders', function(statusCode, headers, resp) {
       if (statusCode >= 300) {
@@ -904,6 +909,7 @@ Client.prototype.downloadStream = function(s3Params) {
       downloadStream.on('finish', function() {
         if (errorOccurred) return;
         cb();
+        currentDownloadRequest = null;
       });
 
       httpStream.pipe(downloadStream);


### PR DESCRIPTION
`currentDownloadRequest` was being used in one function called `doTheDownload`, but there are three different, so we have to use it in all of them. Moreover, we should set it back to `null` when download has finished or has been aborted.